### PR TITLE
fs_mgr: Skip filesystem check unless fs_type matches

### DIFF
--- a/fs_mgr/Android.mk
+++ b/fs_mgr/Android.mk
@@ -10,7 +10,8 @@ common_static_libraries := \
     libmincrypt \
     libcrypto_static \
     libext4_utils_static \
-    libsquashfs_utils
+    libsquashfs_utils \
+    libext2_blkid
 
 include $(CLEAR_VARS)
 LOCAL_CLANG := true
@@ -26,7 +27,10 @@ LOCAL_C_INCLUDES := \
     system/vold \
     system/extras/ext4_utils \
     external/openssl/include \
-    bootable/recovery
+    bootable/recovery \
+    system/extras/ext4_utils \
+    system/extras/squashfs_utils \
+    external/e2fsprogs/lib
 LOCAL_MODULE:= libfs_mgr
 LOCAL_STATIC_LIBRARIES := $(common_static_libraries)
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include

--- a/init/Android.mk
+++ b/init/Android.mk
@@ -101,7 +101,10 @@ LOCAL_STATIC_LIBRARIES := \
     libc++_static \
     libdl \
     libsparse_static \
-    libz
+    libz \
+    libext2_blkid \
+    libext2_uuid_static
+
 
 # Create symlinks
 LOCAL_POST_INSTALL_CMD := $(hide) mkdir -p $(TARGET_ROOT_OUT)/sbin; \


### PR DESCRIPTION
* Prevent accidentally destroying a partition of the wrong type.
* Don't skip iterations of the internal mount_all loop, otherwise
  encryptability may not be properly handled.

Change-Id: I8f3ddc396a5fb85f4ae0a0a11dd61fb4d6462d6d