### PR TITLE
Revert "Create "theme extras" directory"

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -456,7 +456,6 @@ on post-fs-data
     mkdir /data/system 0775 system system
     mkdir /data/system/heapdump 0700 system system
     mkdir /data/system/users 0775 system system
-    mkdir /data/system/theme 0755 system system
 
     mkdir /data/system_de 0770 system system
     mkdir /data/system_ce 0770 system system


### PR DESCRIPTION
This is now handled by ThemeInterfacer as a result of this commit:
https://github.com/substratum/interfacer/commit/bed5f4407b372fa999df54a18939149b1f029a9c

This reverts commit 18efe6241e54163171159f35c2def97e3c7e7498.

Change-Id: I7b58e975f88f4dd9f88368319cfec7f058a6be8c
Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>